### PR TITLE
Exception when using a custom field that inherits from Django's base Field class

### DIFF
--- a/export/fields.py
+++ b/export/fields.py
@@ -258,6 +258,14 @@ class DateTimeField(forms.fields.DateTimeField):
         return queryset.filter(**kwargs)
 
 
+class Field(forms.fields.Field):
+    def __init__(self, field, *args, **kwargs):
+        super(Field, self).__init__(
+            required=False,
+            *args, **kwargs)
+        )
+
+
 class FileField(BasicTextField):
     pass
 


### PR DESCRIPTION
This was a quick fix so that custom fields don't break the export form.  It adds a Field class and sets its required parameter to False.

It would be nice to be able to declare/register settings for models, e.g. to define which fields are available for export, default set of fields to export, default serialization format, default ordering, etc.
